### PR TITLE
Adjustment to get the compiler to finish the jitting

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/AsyncMethodDesc.cs
+++ b/src/coreclr/tools/Common/JitInterface/AsyncMethodDesc.cs
@@ -10,6 +10,7 @@ namespace Internal.JitInterface
     /// <summary>
     /// Represents the async-callable (CORINFO_CALLCONV_ASYNCCALL) variant of a Task/ValueTask returning method.
     /// The wrapper should be short‑lived and only used while interacting with the JIT interface.
+    /// NOPE: These things aren't short lived in R2R scenarios. Please make a normal method, and give them normal, long lifetimes
     /// </summary>
     internal sealed class AsyncMethodDesc : MethodDelegator, IJitHashableOnly
     {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -708,8 +708,8 @@ namespace ILCompiler.DependencyAnalysis
             ManifestMetadataTable = new ManifestMetadataTableNode(this);
             Header.Add(Internal.Runtime.ReadyToRunSectionType.ManifestMetadata, ManifestMetadataTable, ManifestMetadataTable);
             Resolver.SetModuleIndexLookup(ManifestMetadataTable.ModuleToIndex);
-            ((ReadyToRunILProvider)ilProvider).InitManifestMutableModule(ManifestMetadataTable._mutableModule);
             Resolver.InitManifestMutableModule(ManifestMetadataTable._mutableModule);
+            ((ReadyToRunILProvider)ilProvider).InitManifestMutableModule(ManifestMetadataTable._mutableModule, Resolver);
 
             ManifestAssemblyMvidHeaderNode mvidTableNode = new ManifestAssemblyMvidHeaderNode(ManifestMetadataTable);
             Header.Add(Internal.Runtime.ReadyToRunSectionType.ManifestAssemblyMvids, mvidTableNode, mvidTableNode);

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1410,8 +1410,17 @@ namespace Internal.JitInterface
                     // using instantiation parameters from the MethodDesc entity.
                     resultMethod = resultMethod.GetTypicalMethodDefinition();
 
+                    if (resultMethod is AsyncMethodDesc asyncMethodDescMethod)
+                    {
+                        resultMethod = asyncMethodDescMethod.Target;
+                    }
                     Debug.Assert(resultMethod is EcmaMethod);
-                    Debug.Assert(_compilation.NodeFactory.CompilationModuleGroup.VersionsWithType(((EcmaMethod)resultMethod).OwningType));
+                    if (!_compilation.NodeFactory.CompilationModuleGroup.VersionsWithType(((EcmaMethod)resultMethod).OwningType))
+                    {
+                        // TODO Add assert that the method is one of the R2RKnownMethods
+                        ModuleToken result = _compilation.NodeFactory.SignatureContext.Resolver.GetModuleTokenForMethod(resultMethod, allowDynamicallyCreatedReference: true, throwIfNotFound: true);
+                        return result;
+                    }
                     token = (mdToken)MetadataTokens.GetToken(((EcmaMethod)resultMethod).Handle);
                     module = ((EcmaMethod)resultMethod).Module;
                 }
@@ -1431,7 +1440,12 @@ namespace Internal.JitInterface
                 {
                     if (resultDef is EcmaType ecmaType)
                     {
-                        Debug.Assert(_compilation.NodeFactory.CompilationModuleGroup.VersionsWithType(ecmaType));
+                        if (!_compilation.NodeFactory.CompilationModuleGroup.VersionsWithType(ecmaType))
+                        {
+                            // TODO Add assert that the method is one of the R2RKnownTypes
+                            ModuleToken result = _compilation.NodeFactory.SignatureContext.Resolver.GetModuleTokenForType(ecmaType, allowDynamicallyCreatedReference: true, throwIfNotFound: true);
+                            return result;
+                        }
                         token = (mdToken)MetadataTokens.GetToken(ecmaType.Handle);
                         module = ecmaType.Module;
                     }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/TypeSystem/Mutable/MutableModule.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/TypeSystem/Mutable/MutableModule.cs
@@ -39,7 +39,7 @@ namespace Internal.TypeSystem.Ecma
                 if (!_mutableModule._moduleToModuleRefString.TryGetValue(module, out moduleRefString))
                 {
                     Debug.Assert(_mutableModule.ModuleThatIsCurrentlyTheSourceOfNewReferences != null &&
-                        _mutableModule._compilationGroup.CrossModuleInlineableModule(_mutableModule.ModuleThatIsCurrentlyTheSourceOfNewReferences));
+                        _mutableModule._compilationGroup.CrossModuleInlineableModule(_mutableModule.ModuleThatIsCurrentlyTheSourceOfNewReferences) || _mutableModule.AddingReferencesToR2RKnownTypesAndMethods);
 
                     if (module == _typeSystemContext.SystemModule)
                     {
@@ -303,6 +303,7 @@ namespace Internal.TypeSystem.Ecma
 
         public bool DisableNewTokens;
         public ModuleDesc ModuleThatIsCurrentlyTheSourceOfNewReferences;
+        public bool AddingReferencesToR2RKnownTypesAndMethods;
         private ReadyToRunCompilationModuleGroupBase _compilationGroup;
         private Dictionary<ModuleDesc, string> _moduleToModuleRefString = new Dictionary<ModuleDesc, string>();
 


### PR DESCRIPTION
Notably, I've tweak the cross module inlining feature to enable compilation of the tokens needed in these thunks. The tweak enables using these particular apis without enabling the cross module switch. It successfully finishes jitting a method.

- This does not ... handle the dependency graph issues
- I've noticed that we seem to make the thunks as temporary things, and assume they don't need process long lifetime. This is not likely to true, as they are actual useable symbols, so that needs to be fixed so that the various thunk methoddescs aren't treated as transient. (Anything which is a symbol or goes in the dependency graph needs to be non-transient, and able to be looked up later. Newing up a new instance is not a valid thing to do.)
- We seem to have a concept of thunks and whatnot in the MethodDescs... I'm seeing us compile the original method... with the IL for a thunk, and then I'm seeing something try to add to the dependency graph a thunk which is supposed to have the calling convention of the method we just compiled, but is MethodDesc of type TaskReturnAsyncMethodDescThunk or something.