### PR TITLE
Suppress DOTNET_GCHeapAffinitizeRanges during crossgen2 execution

### DIFF
--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -158,7 +158,7 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
         cat "$__ResponseFile"
 
         # Suppress some DOTNET variables for the duration of Crossgen2 execution
-        export -n DOTNET_GCName DOTNET_GCStress DOTNET_HeapVerify DOTNET_ReadyToRun
+        export -n DOTNET_GCName DOTNET_GCStress DOTNET_HeapVerify DOTNET_ReadyToRun DOTNET_GCHeapAffinitizeRanges
         # FIXME: Remove this?
         # work around problems in 6.0 OSR
         export -n DOTNET_TC_OnStackReplacement DOTNET_TC_PartialCompilation
@@ -179,7 +179,7 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
         $__R2RDumpCommand
         __r2rDumpExitCode=$?
 
-        export DOTNET_GCName DOTNET_GCStress DOTNET_HeapVerify DOTNET_ReadyToRun
+        export DOTNET_GCName DOTNET_GCStress DOTNET_HeapVerify DOTNET_ReadyToRun DOTNET_GCHeapAffinitizeRanges
         export DOTNET_TC_OnStackReplacement DOTNET_TC_PartialCompilation
         date +%H:%M:%S
       }
@@ -376,6 +376,7 @@ if defined RunCrossGen2 (
     set "DOTNET_GCStress="
     set "DOTNET_HeapVerify="
     set "DOTNET_ReadyToRun="
+    set "DOTNET_GCHeapAffinitizeRanges="
 
     REM FIXME: remove this?
     REM work around problems in 6.0 OSR


### PR DESCRIPTION
## Summary

Fixes #130289.

The `GC/API/GC/GetConfigurationVariables` test sets `DOTNET_GCHeapAffinitizeRanges=1` via `CLRTestEnvironmentVariable`. crossgen2 embeds **Server GC**, which parses the heap-affinity configuration during heap initialization. On Windows the value must use the `group:index` format (e.g. `0:1`), so the bare `1` is invalid and the runtime aborts before `Main` with `CLR_E_GC_BAD_AFFINITY_CONFIG_FORMAT`. This crashes crossgen2 (exit code `-1`, no output) and fails the test on the R2R-CG2 Windows outerloop leg.

The crossgen2 suppress-list in `CLRTest.CrossGen.targets` already clears GC/JIT diagnostic variables (`DOTNET_GCName`, `DOTNET_GCStress`, `DOTNET_HeapVerify`, `DOTNET_ReadyToRun`, ...) so crossgen2 — a build tool — doesn't inherit the *target* process's runtime configuration. `DOTNET_GCHeapAffinitizeRanges` belongs in that list too. This change adds it in all three spots:

- Unix bash `export -n` (un-export before crossgen2)
- Unix bash restore `export` (re-export after)
- Windows batch `set "...="` block (inside the existing `setlocal`/`endlocal`)

The normal test run is unaffected: under Workstation GC the value is never parsed, just echoed back, so the existing `Value="1"` and the test's `== "1"` assertion continue to pass on all platforms.

## Why now

The env var was added on 5/29 (#128455) but lay dormant — crossgen2 was Workstation GC and ignored it. The 7/06 SDK bump (#130154) rebuilt crossgen2 with Server GC, which activated the affinity parse and started the failures. Timeline confirmed by bisecting the outerloop pipeline and by git-ancestry correlation of passing/failing builds.

## Validation

Reproduced and validated on Windows via Helix (`Windows.11.Amd64.Client.Open`, x86 crossgen2):

| Variant | Environment | Result |
|---|---|---|
| G0 | (no env var) | ✅ exit 0 — emits R2R PE |
| G1 | `DOTNET_GCHeapAffinitizeRanges=1` | ❌ exit -1 |
| G2 | `...=1` + `DOTNET_gcServer=0` | ✅ exit 0 |
| G3 | `...=1` + `DOTNET_gcServer=1` | ❌ exit -1 |
| **G4** | **`...=1` then cleared (this fix)** | **✅ exit 0 — emits R2R PE** |

G4 mirrors exactly what the suppress-list does (set the var, then clear it before invoking crossgen2) and confirms the fix.

> [!NOTE]
> This PR was created with the assistance of GitHub Copilot.