### PR TITLE
Gate crossgen2-outerloop non-composite R2R legs by trigger (scheduled vs manual)

### DIFF
--- a/eng/pipelines/coreclr/crossgen2-outerloop.yml
+++ b/eng/pipelines/coreclr/crossgen2-outerloop.yml
@@ -81,6 +81,9 @@ extends:
             unifiedArtifactsName: Checked_CoreCLR_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
 
       # Outerloop testing in non-composite mode
+      # These platforms (linux_arm, osx_arm64) are NOT covered by the
+      # runtime-coreclr outerloop pipeline's (ci.yml) R2R_CG2 job, so run them
+      # on every trigger (scheduled and manual).
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
           jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -88,19 +91,37 @@ extends:
           buildConfig: checked
           platforms:
           - linux_arm
-          - linux_arm64
-          - linux_x64
-          - osx_x64
           - osx_arm64
-          - windows_arm64
-          - windows_x64
-          - windows_x86
           jobParameters:
             testGroup: outerloop
             readyToRun: true
             displayNameArgs: R2R
             liveLibrariesBuildConfig: Release
             unifiedArtifactsName: Checked_CoreCLR_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
+
+      # These platforms overlap with the runtime-coreclr outerloop pipeline's
+      # (ci.yml) R2R_CG2 job, which runs them 3x/day on main. To avoid redundant
+      # work, only run them here on manual invocations (full coverage for
+      # validating a change), not on scheduled runs.
+      - ${{ if ne(variables['Build.Reason'], 'Schedule') }}:
+        - template: /eng/pipelines/common/platform-matrix.yml
+          parameters:
+            jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+            helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+            buildConfig: checked
+            platforms:
+            - linux_arm64
+            - linux_x64
+            - osx_x64
+            - windows_x64
+            - windows_x86
+            - windows_arm64
+            jobParameters:
+              testGroup: outerloop
+              readyToRun: true
+              displayNameArgs: R2R
+              liveLibrariesBuildConfig: Release
+              unifiedArtifactsName: Checked_CoreCLR_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
 
       # Build release CoreCLR for Crossgen2 baseline generation
       - template: /eng/pipelines/common/platform-matrix.yml


### PR DESCRIPTION
## What

Splits the non-composite `R2R` test job in `eng/pipelines/coreclr/crossgen2-outerloop.yml` into two platform-matrix blocks gated by `Build.Reason`, so scheduled (cron) runs skip the R2R legs that are already covered more frequently elsewhere, while manual runs keep full 8-platform coverage.

## Why

`crossgen2-outerloop.yml` runs its non-composite `R2R` job (testGroup `outerloop`, `readyToRun: true`) on 8 platforms once per day. The `runtime-coreclr outerloop` pipeline (`eng/pipelines/coreclr/ci.yml`) has an equivalent `R2R_CG2` job that runs **3x/day on main** (cron `0 9,18,1 * * *`) plus release-branch CI. Six platforms overlap between the two jobs, so on scheduled crossgen2-outerloop runs that work is redundant.

| Platform | ci.yml R2R_CG2 (3x/day) | Action here |
| --- | --- | --- |
| linux_arm64 | ✅ | manual-only |
| linux_x64 | ✅ | manual-only |
| osx_x64 | ✅ | manual-only |
| windows_x64 | ✅ | manual-only |
| windows_x86 | ✅ | manual-only |
| windows_arm64 | ✅ | manual-only |
| **linux_arm** | ❌ | **always on** |
| **osx_arm64** | ❌ | **always on** |

## How

`crossgen2-outerloop.yml` is `trigger: none` + a daily schedule, so its only run reasons are `Schedule` (cron) and `Manual`. The overlapping block is wrapped in a compile-time template gate `- ${{ if ne(variables['Build.Reason'], 'Schedule') }}:`, matching existing `Build.Reason` precedent in `eng/pipelines/runtime-diagnostics.yml` and `eng/pipelines/coreclr/templates/jit-exploratory-variables.yml`.

- **Scheduled run:** only the 2 unique platforms (`linux_arm`, `osx_arm64`) run for the non-composite R2R job.
- **Manual run:** all 8 platforms run (full coverage for validating a change).

The two blocks share identical `jobParameters`, `jobTemplate`, `helixQueuesTemplate`, and `buildConfig` as the original single block — the platform list is just split.

## Not changed

- The **build stage** is left ungated: `global-build-job.yml` keeps building `Checked_CoreCLR` artifacts for all 8 platforms on every trigger, so the manual-only test legs always have artifacts to consume.
- `R2R_Composite`, `R2R_Composite_LargeVersionBubble`, and the crossgen2-comparison jobs are untouched.
- `ci.yml` is untouched. Its unique musl coverage is unaffected.

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.